### PR TITLE
Update assume-role to v0.3.0

### DIFF
--- a/assume-role.rb
+++ b/assume-role.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class AssumeRole < Formula
   homepage 'https://github.com/coinbase/assume-role'
-  url 'https://github.com/coinbase/assume-role/archive/v0.2.0.tar.gz'
-  sha256 'd737d9ddd10a74e960e608b0a1e29e61fea2655f03ba3dbc0a4a9019c0700754'
+  url 'https://github.com/coinbase/assume-role/archive/v0.3.0.tar.gz'
+  sha256 'TODO'
 
   depends_on "awscli"
   depends_on "jq"


### PR DESCRIPTION
Update assume-role from v0.2.0 to v0.3.0.

TODO: Make a release on [coinbase/assume-role](github.com/coinbase/assume-role) at `e3faf991f390bc3a07763b33a44ead5f0c9ed6f4` (head of master) for v0.3.0. Once that is done, we can update the sha256 in this PR, and merge this.